### PR TITLE
tasks should not throw and catch exceptions for expected errors / error situations

### DIFF
--- a/src/include/baselib/async/AsyncOperation.h
+++ b/src/include/baselib/async/AsyncOperation.h
@@ -72,7 +72,8 @@ namespace bl
      * operation has been canceled by checking the operation pointer for
      * nullptr (this will also normally be indicated by the m_cancelRequested
      * member being set to true); note that the helper prolog macros
-     * BL_TASKS_HANDLER_BEGIN_CHK_ASYNC_RESULT_IMPL() and
+     * BL_TASKS_HANDLER_CHK_ASYNC_RESULT_IMPL() and
+     * BL_TASKS_HANDLER_CHK_ASYNC_RESULT_IMPL_THROW() and
      * BL_TASKS_HANDLER_BEGIN_CHK_ASYNC_RESULT() defined in TaskBase account
      * for this case and handle it correctly
      */

--- a/src/include/baselib/messaging/TcpBlockTransferClient.h
+++ b/src/include/baselib/messaging/TcpBlockTransferClient.h
@@ -1529,7 +1529,14 @@ namespace bl
                                 );
                         }
 
-                        if( exception && ! messaging::BrokerErrorCodes::isExpectedException( exception ) )
+                        if(
+                            exception &&
+                            (
+                                terminatedGracefully ||
+                                m_stopWasRequested ||
+                                ! messaging::BrokerErrorCodes::isExpectedException( exception )
+                            )
+                            )
                         {
                             if( ! terminatedGracefully )
                             {

--- a/src/include/baselib/messaging/TcpBlockTransferServer.h
+++ b/src/include/baselib/messaging/TcpBlockTransferServer.h
@@ -368,7 +368,7 @@ namespace bl
 
             void doChkAsyncResult( SAA_in const AsyncOperation::Result& result )
             {
-                BL_TASKS_HANDLER_BEGIN_CHK_ASYNC_RESULT_IMPL( result )
+                BL_TASKS_HANDLER_CHK_ASYNC_RESULT_IMPL_THROW( result )
             }
 
             bool chkAsyncResult( SAA_in const AsyncOperation::Result& result )


### PR DESCRIPTION
Fixing issue #84 (tasks should not throw and catch exceptions for expected errors / error situations)