### PR TITLE
tasks should not throw and catch exceptions for expected errors / error situations

### DIFF
--- a/src/include/baselib/core/AppInitDone.h
+++ b/src/include/baselib/core/AppInitDone.h
@@ -181,7 +181,8 @@ namespace bl
                 {
                     m_threadPoolNonBlocking = ThreadPoolImplDefault::template createInstance< ThreadPool >(
                         os::getAbstractPriorityDefault(),
-                        ThreadPoolDefault::IO_THREADS_COUNT
+                        threadsCount < ThreadPoolDefault::IO_THREADS_COUNT
+                            ? threadsCount : ThreadPoolDefault::IO_THREADS_COUNT
                         );
 
                     ThreadPoolDefault::setDefault(

--- a/src/include/baselib/tasks/TaskBase.h
+++ b/src/include/baselib/tasks/TaskBase.h
@@ -109,11 +109,12 @@
     std::exception_ptr __eptr42 = nullptr; \
     bool __isExpectedException42 = false; \
     { \
+        lockExpr \
+        \
         try \
         { \
             do \
             { \
-                lockExpr \
 
 #define BL_TASKS_HANDLER_BEGIN() \
     BL_TASKS_HANDLER_BEGIN_IMPL( BL_MUTEX_GUARD( bl::tasks::TaskBase::m_lock ); ) \
@@ -190,14 +191,6 @@
 #define BL_TASKS_HANDLER_END_IMPL( expr ) \
             } \
             while( false ); \
-            if( __eptr42 ) \
-            { \
-                bl::tasks::TaskBase::notifyReady( __eptr42, __isExpectedException42 ); \
-            } \
-            else \
-            { \
-                expr \
-            } \
         } \
         catch( bl::eh::exception& e ) \
         { \
@@ -212,6 +205,10 @@
     if( __eptr42 ) \
     { \
         bl::tasks::TaskBase::notifyReady( __eptr42, __isExpectedException42 ); \
+    } \
+    else \
+    { \
+        expr \
     } \
     BL_NOEXCEPT_END() \
 

--- a/src/include/baselib/tasks/TcpSslBaseTasks.h
+++ b/src/include/baselib/tasks/TcpSslBaseTasks.h
@@ -428,7 +428,9 @@ namespace bl
 
                 if( asio::error::eof != ec )
                 {
-                    if( ! isExpectedSslErrorCode( ec ) )
+                    const auto exception = SystemException::create( ec, BL_SYSTEM_ERROR_DEFAULT_MSG );
+
+                    if( ! isExpectedException( nullptr /* eptr */, exception, &ec ) )
                     {
                         if( m_originalException )
                         {
@@ -440,9 +442,7 @@ namespace bl
                                 Logging::debug(),
                                 BL_MSG()
                                     << "Unexpected exception during SSL shutdown; exception details:\n"
-                                    << eh::diagnostic_information(
-                                        SystemException::create( ec, BL_SYSTEM_ERROR_DEFAULT_MSG )
-                                        )
+                                    << eh::diagnostic_information( exception )
                                 );
                         }
                         else


### PR DESCRIPTION
More fixes for issue #85 (tasks should not throw and catch exceptions for expected errors / error situations)