### PR TITLE
tasks should not throw and catch exceptions for expected errors / error situations

### DIFF
--- a/src/include/baselib/http/SimpleHttpTask.h
+++ b/src/include/baselib/http/SimpleHttpTask.h
@@ -185,7 +185,10 @@ namespace bl
                 return g_protocolDefault;
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 BL_NOEXCEPT_BEGIN()
@@ -215,7 +218,7 @@ namespace bl
 
                 BL_NOEXCEPT_END()
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
             virtual void cancelTask() OVERRIDE

--- a/src/include/baselib/messaging/TcpBlockTransferClient.h
+++ b/src/include/baselib/messaging/TcpBlockTransferClient.h
@@ -788,7 +788,10 @@ namespace bl
                 return false;
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 /*
@@ -802,7 +805,7 @@ namespace bl
 
                 m_commandId = CommandId::NoCommand;
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
             virtual void scheduleTask( SAA_in const std::shared_ptr< ExecutionQueue >& eq ) OVERRIDE

--- a/src/include/baselib/messaging/TcpBlockTransferServer.h
+++ b/src/include/baselib/messaging/TcpBlockTransferServer.h
@@ -1521,7 +1521,10 @@ namespace bl
                 m_connectedSessionId = uuids::create();
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 BL_NOEXCEPT_BEGIN()
@@ -1542,7 +1545,7 @@ namespace bl
 
                 BL_NOEXCEPT_END()
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
         public:

--- a/src/include/baselib/tasks/TaskBase.h
+++ b/src/include/baselib/tasks/TaskBase.h
@@ -488,6 +488,7 @@ namespace bl
 
                 cpp::void_callback_noexcept_t cbReady;
                 std::exception_ptr eptr = eptrIn;
+                bool isExpected = isExpectedException;
 
                 {
                     BL_MUTEX_GUARD( m_lock );
@@ -530,7 +531,7 @@ namespace bl
                         }
                     }
 
-                    eptr = onTaskStoppedNothrow( eptr );
+                    eptr = onTaskStoppedNothrow( eptr, &isExpected );
 
                     if( m_notifyCalled )
                     {
@@ -545,7 +546,7 @@ namespace bl
 
                     if( ! m_name.empty() )
                     {
-                        if( ! isExpectedException && ( eptr || m_exception ) )
+                        if( ! isExpected && ( eptr || m_exception ) )
                         {
                             /*
                              * The exception is available via m_exception or eptr (m_exception takes priority)
@@ -828,9 +829,14 @@ namespace bl
              * This task can also be used to re-map the final exception if desired
              */
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr
             {
+                BL_UNUSED( isExpectedException );
+
                 return eptrIn;
             }
 

--- a/src/include/baselib/tasks/TcpBaseTasks.h
+++ b/src/include/baselib/tasks/TcpBaseTasks.h
@@ -107,14 +107,17 @@ namespace bl
                     );
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 std::exception_ptr eptr;
 
                 BL_NOEXCEPT_BEGIN()
 
-                eptr = base_type::onTaskStoppedNothrow( eptrIn );
+                eptr = base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
 
                 if( base_type::isCanceled() && m_wasSocketShutdownForcefully )
                 {
@@ -130,6 +133,11 @@ namespace bl
                     }
 
                     eptr  = std::make_exception_ptr( exception );
+
+                    if( isExpectedException )
+                    {
+                        *isExpectedException = this -> isExpectedException( eptr, exception, &exception.code() );
+                    }
                 }
 
                 BL_NOEXCEPT_END()
@@ -574,7 +582,10 @@ namespace bl
                  */
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 BL_NOEXCEPT_BEGIN()
@@ -586,7 +597,7 @@ namespace bl
 
                 BL_NOEXCEPT_END()
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
         public:
@@ -858,7 +869,10 @@ namespace bl
                 TaskBase::m_name = "success:TcpTask_Acceptor";
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 BL_NOEXCEPT_BEGIN()
@@ -872,7 +886,7 @@ namespace bl
 
                 BL_NOEXCEPT_END()
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
             void startAccept()
@@ -994,7 +1008,7 @@ namespace bl
                             << net::formatEndpointId( m_localEndpoint )
                         );
 
-                    BL_CHK_EC_NM( m_errorCode );
+                    BL_TASKS_HANDLER_CHK_EC( m_errorCode );
                 }
                 else
                 {
@@ -1646,7 +1660,10 @@ namespace bl
                 return detail::HandshakeTaskHelper< STREAM >::createTask( BL_PARAM_FWD( connectedStream ) );
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 if( eptrIn )
@@ -1693,7 +1710,7 @@ namespace bl
                     m_controlToken -> unregisterCancelableTask( om::ObjPtrCopyable< Task >::acquireRef( this ) );
                 }
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
             virtual void onEvent(
@@ -1873,7 +1890,7 @@ namespace bl
                     }
                 }
 
-                BL_CHK_EC_NM( base_type::m_errorCode );
+                BL_TASKS_HANDLER_CHK_EC( base_type::m_errorCode );
 
                 BL_TASKS_HANDLER_END()
             }

--- a/src/include/baselib/tasks/TcpSslBaseTasks.h
+++ b/src/include/baselib/tasks/TcpSslBaseTasks.h
@@ -346,7 +346,10 @@ namespace bl
                 return true;
             }
 
-            virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+            virtual auto onTaskStoppedNothrow(
+                SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                ) NOEXCEPT
                 -> std::exception_ptr OVERRIDE
             {
                 BL_NOEXCEPT_BEGIN()
@@ -358,7 +361,7 @@ namespace bl
 
                 BL_NOEXCEPT_END()
 
-                return base_type::onTaskStoppedNothrow( eptrIn );
+                return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
             }
 
             void beginProtocolShutdown( SAA_in_opt const std::exception_ptr& eptrIn )

--- a/src/include/baselib/transfer/FilesUnpackagerUnit.h
+++ b/src/include/baselib/transfer/FilesUnpackagerUnit.h
@@ -900,7 +900,10 @@ namespace bl
                     }
                 }
 
-                virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+                virtual auto onTaskStoppedNothrow(
+                    SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+                    SAA_inout_opt           bool*                                       isExpectedException = nullptr
+                    ) NOEXCEPT
                     -> std::exception_ptr OVERRIDE
                 {
                     BL_NOEXCEPT_BEGIN()
@@ -926,7 +929,7 @@ namespace bl
 
                     BL_NOEXCEPT_END()
 
-                    return base_type::onTaskStoppedNothrow( eptrIn );
+                    return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
                 }
 
                 virtual void onExecute() NOEXCEPT OVERRIDE

--- a/src/utests/include/utests/baselib/TestAsyncCommon.h
+++ b/src/utests/include/utests/baselib/TestAsyncCommon.h
@@ -86,7 +86,10 @@ namespace utest
             releaseOperation();
         }
 
-        virtual auto onTaskStoppedNothrow( SAA_in_opt const std::exception_ptr& eptrIn ) NOEXCEPT
+        virtual auto onTaskStoppedNothrow(
+            SAA_in_opt              const std::exception_ptr&                   eptrIn = nullptr,
+            SAA_inout_opt           bool*                                       isExpectedException = nullptr
+            ) NOEXCEPT
             -> std::exception_ptr OVERRIDE
         {
             BL_NOEXCEPT_BEGIN()
@@ -107,7 +110,7 @@ namespace utest
 
             BL_NOEXCEPT_END()
 
-            return base_type::onTaskStoppedNothrow( eptrIn );
+            return base_type::onTaskStoppedNothrow( eptrIn, isExpectedException );
         }
 
         virtual void cancelTask() OVERRIDE


### PR DESCRIPTION
Staging for issue #85 (tasks should not throw and catch exceptions for expected errors / error situations)