### PR TITLE
tasks should not throw and catch exceptions for expected errors / error situations

### DIFF
--- a/src/include/baselib/core/ErrorHandling.h
+++ b/src/include/baselib/core/ErrorHandling.h
@@ -702,14 +702,21 @@ namespace bl
     {
     public:
 
-        virtual const char* fullTypeName() const NOEXCEPT OVERRIDE
+        static const char* fullTypeNameStatic() NOEXCEPT
         {
             return "bl::UserMessageException";
+        }
+
+        virtual const char* fullTypeName() const NOEXCEPT OVERRIDE
+        {
+            return fullTypeNameStatic();
         }
 
         UserMessageExceptionT()
         {
             BL_MAKE_USER_FRIENDLY( *this );
+
+            ( *this ) << bl::eh::errinfo_full_type_name( fullTypeNameStatic() );
         }
     };
 
@@ -783,9 +790,14 @@ namespace bl
 
     public:
 
-        virtual const char* fullTypeName() const NOEXCEPT OVERRIDE
+        static const char* fullTypeNameStatic() NOEXCEPT
         {
             return "bl::SystemException";
+        }
+
+        virtual const char* fullTypeName() const NOEXCEPT OVERRIDE
+        {
+            return fullTypeNameStatic();
         }
 
         virtual const char* what() const NOTHROW_REAL OVERRIDE
@@ -800,6 +812,8 @@ namespace bl
              */
 
             SystemException exception( code, msg );
+
+            exception << bl::eh::errinfo_full_type_name( fullTypeNameStatic() );
 
             if( code.category() == eh::system_category() )
             {

--- a/src/include/baselib/tasks/TcpSslBaseTasks.h
+++ b/src/include/baselib/tasks/TcpSslBaseTasks.h
@@ -429,7 +429,7 @@ namespace bl
                  * http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
                  */
 
-                if( asio::error::eof != ec )
+                if( ec && asio::error::eof != ec )
                 {
                     auto exception = BL_EXCEPTION(
                         SystemException::create( ec, BL_SYSTEM_ERROR_DEFAULT_MSG ),


### PR DESCRIPTION
Staging for issue #85 (tasks should not throw and catch exceptions for expected errors / error situations)