### PR TITLE
Provide way to not define default global utf fixture

### DIFF
--- a/src/utests/include/utests/baselib/UtfMain.h
+++ b/src/utests/include/utests/baselib/UtfMain.h
@@ -374,5 +374,6 @@ DefaultUtfConfigT< E >::g_defaultLogger = bl::Logging::getDefaultLineLogger();
 
 typedef DefaultUtfConfigT<> DefaultUtfConfig;
 
-UTF_GLOBAL_FIXTURE( DefaultUtfConfig )
-
+#ifndef BL_NO_DEFAULT_UTF_GLOBAL_FIXTURE
+    UTF_GLOBAL_FIXTURE( DefaultUtfConfig )
+#endif


### PR DESCRIPTION
Provide way to not define default global utf fixture to help with initialization order