### PR TITLE
Improve JNI exception handling

### DIFF
--- a/src/include/baselib/core/ErrorHandling.h
+++ b/src/include/baselib/core/ErrorHandling.h
@@ -469,6 +469,10 @@ namespace bl
         typedef error_info< struct errinfo_parser_reason_, std::string >                        errinfo_parser_reason;
         typedef error_info< struct errinfo_external_command_output_, std::string >              errinfo_external_command_output;
         typedef error_info< struct errinfo_external_command_exit_code_, int >                   errinfo_external_command_exit_code;
+        typedef error_info< struct errinfo_original_message_, std::string >                     errinfo_original_message;
+        typedef error_info< struct errinfo_original_type_, std::string >                        errinfo_original_type;
+        typedef error_info< struct errinfo_original_thread_name_, std::string >                 errinfo_original_thread_name;
+        typedef error_info< struct errinfo_original_stack_trace_, std::string >                 errinfo_original_stack_trace;
         typedef error_info< struct errinfo_string_value_, std::string >                         errinfo_string_value;
         typedef error_info< struct errinfo_is_user_friendly_, bool >                            errinfo_is_user_friendly;
         typedef error_info< struct errinfo_ssl_is_verify_failed_, bool >                        errinfo_ssl_is_verify_failed;

--- a/src/include/baselib/core/StringUtils.h
+++ b/src/include/baselib/core/StringUtils.h
@@ -1179,8 +1179,9 @@ namespace bl
                     InvalidDataFormatException()
                         << eh::errinfo_is_user_friendly( true ),
                     BL_MSG()
-                        << "Duplicate property encountered name while parsing "
-                        << "concatenated properties in 'name=value' format"
+                        << "Duplicate property "
+                        << bl::str::quoteString( pair.first -> first )
+                        << " encountered while parsing concatenated properties in 'name=value' format"
                     );
             }
 

--- a/src/include/baselib/messaging/GraphQLErrorHelpers.h
+++ b/src/include/baselib/messaging/GraphQLErrorHelpers.h
@@ -78,7 +78,14 @@ namespace bl
 
                 auto message = expected.empty() ? error -> message() : expected;
 
-                result -> message( std::move( message ) + " [error code " +  std::to_string( errorCode ) + "]" );
+                if( errorCode != eh::errc::errc_t::success )
+                {
+                    message.append( " (error code "  );
+                    message.append( std::to_string( errorCode ) );
+                    message.append( ")" );
+                }
+
+                result -> message( std::move( message ) );
 
                 errorGraphQL -> errorsLvalue().push_back( std::move( result ) );
 

--- a/src/utests/utf_baselib/TestBaselibDefault.h
+++ b/src/utests/utf_baselib/TestBaselibDefault.h
@@ -4811,11 +4811,7 @@ UTF_AUTO_TEST_CASE( BaseLib_StringUtilsParsePropertiesListTests )
     UTF_REQUIRE_THROW_MESSAGE(
         str::parsePropertiesList( ";name1=value1; name1=value2" ),
         bl::InvalidDataFormatException,
-        bl::resolveMessage(
-            BL_MSG()
-                << "Duplicate property encountered name while parsing "
-                << "concatenated properties in 'name=value' format"
-        )
+        "Duplicate property"
         );
 }
 


### PR DESCRIPTION
Several fixes:
* Added several new errorinfo fields to avoid dumping all Java exception info single exception message string.
* Don't print success (0) error code in GraphQL error messages.
* Print property name in case of duplicated property.