### PR TITLE
Propagate the original Java exception message in wrapper C++ exceptions

### DIFF
--- a/src/include/baselib/core/ErrorHandling.h
+++ b/src/include/baselib/core/ErrorHandling.h
@@ -469,7 +469,7 @@ namespace bl
         typedef error_info< struct errinfo_parser_reason_, std::string >                        errinfo_parser_reason;
         typedef error_info< struct errinfo_external_command_output_, std::string >              errinfo_external_command_output;
         typedef error_info< struct errinfo_external_command_exit_code_, int >                   errinfo_external_command_exit_code;
-        typedef error_info< struct errinfo_original_message_, std::string >                     errinfo_original_message;
+        typedef error_info< struct errinfo_hint_, std::string >                                 errinfo_hint;
         typedef error_info< struct errinfo_original_type_, std::string >                        errinfo_original_type;
         typedef error_info< struct errinfo_original_thread_name_, std::string >                 errinfo_original_thread_name;
         typedef error_info< struct errinfo_original_stack_trace_, std::string >                 errinfo_original_stack_trace;

--- a/src/include/baselib/jni/JniEnvironment.h
+++ b/src/include/baselib/jni/JniEnvironment.h
@@ -166,6 +166,7 @@ namespace bl
                 ) const
             {
                 auto exception = JavaException();
+                std::string message;
 
                 if( g_exceptionHandlingBootstrapped )
                 {
@@ -179,7 +180,7 @@ namespace bl
                         g_threadGetName
                         );
 
-                    const auto message = callObjectMethod< jstring >(
+                    const auto javaMessage = callObjectMethod< jstring >(
                         throwable.get(),
                         g_throwableGetMessage
                         );
@@ -198,15 +199,21 @@ namespace bl
 
                     appendStackTraceElements( stackTrace, throwable );
 
+                    message = javaStringToCString( javaMessage );
+
                     exception
-                        << eh::errinfo_original_message( javaStringToCString( message ) )
+                        << eh::errinfo_hint( cbMessage() )
                         << eh::errinfo_original_type( getClassName( javaClass.get() ) )
                         << eh::errinfo_original_thread_name( javaStringToCString( threadName ) )
                         << eh::errinfo_original_stack_trace( stackTrace.str() )
                         << eh::errinfo_string_value( javaStringToCString( toString ) );
                 }
+                else
+                {
+                    message = cbMessage();
+                }
 
-                BL_THROW( std::move( exception ), cbMessage() );
+                BL_THROW( std::move( exception ), message );
             }
 
             void appendStackTraceElements(

--- a/src/utests/utf_baselib_jni/TestJni.h
+++ b/src/utests/utf_baselib_jni/TestJni.h
@@ -199,9 +199,14 @@ UTF_AUTO_TEST_CASE( Jni_JavaExceptions )
                     << eh::diagnostic_information( e )
                 );
 
-            const auto* messagePtr = eh::get_error_info< eh::errinfo_original_message >( e );
+            if( e.what() != std::string( "no/such/class" ) )
+            {
+                return false;
+            }
 
-            if( ! messagePtr || *messagePtr != "no/such/class" )
+            const auto* hintPtr = eh::get_error_info< eh::errinfo_hint >( e );
+
+            if( ! hintPtr || *hintPtr != "Java class 'no/such/class' not found" )
             {
                 return false;
             }
@@ -243,19 +248,39 @@ UTF_AUTO_TEST_CASE( Jni_JavaExceptions )
     const auto threadGetName = environment.getMethodID( threadClass.get(), "getName", "()Ljava/lang/String;" );
     UTF_REQUIRE( threadGetName != nullptr );
 
-    UTF_CHECK_THROW_MESSAGE(
+    UTF_CHECK_EXCEPTION(
         environment.getMethodID( threadClass.get(), "foo", "()Ljava/lang/String;" ),
         JavaException,
-        "Method 'foo' with signature '()Ljava/lang/String;' not found in class 'java.lang.Thread'"
+        []( SAA_in const JavaException& e ) -> bool
+        {
+            const auto* hintPtr = eh::get_error_info< eh::errinfo_hint >( e );
+
+            if( ! hintPtr || *hintPtr != "Method 'foo' with signature '()Ljava/lang/String;' not found in class 'java.lang.Thread'" )
+            {
+                return false;
+            }
+
+            return true;
+        }
         );
 
     const auto threadCurrentThread = environment.getStaticMethodID( threadClass.get(), "currentThread", "()Ljava/lang/Thread;" );
     UTF_REQUIRE( threadCurrentThread != nullptr );
 
-    UTF_CHECK_THROW_MESSAGE(
+    UTF_CHECK_EXCEPTION(
         environment.getStaticMethodID( threadClass.get(), "foo", "()Ljava/lang/Thread;" ),
         JavaException,
-        "Static method 'foo' with signature '()Ljava/lang/Thread;' not found in class 'java.lang.Thread'"
+        []( SAA_in const JavaException& e ) -> bool
+        {
+            const auto* hintPtr = eh::get_error_info< eh::errinfo_hint >( e );
+
+            if( ! hintPtr || *hintPtr != "Static method 'foo' with signature '()Ljava/lang/Thread;' not found in class 'java.lang.Thread'" )
+            {
+                return false;
+            }
+
+            return true;
+        }
         );
 }
 


### PR DESCRIPTION
Several place in code rely on the original Java exception message to be propagate as user-visible error message hence this change is required. The C++ specific string associated with the Java exception is now stored as a new errinfo_hint exception property.