### PR TITLE
Avoid http gateway log noise

### DIFF
--- a/src/include/baselib/httpserver/HttpServer.h
+++ b/src/include/baselib/httpserver/HttpServer.h
@@ -500,8 +500,10 @@ namespace bl
             }
         };
 
-        typedef om::ObjectImpl< HttpServerT< tasks::TcpSocketAsyncBase > >           HttpServer;
-        typedef om::ObjectImpl< HttpServerT< tasks::TcpSslSocketAsyncBase > >        HttpSslServer;
+        typedef om::ObjectImpl< HttpServerT< tasks::TcpSocketAsyncBase > >                                  HttpServer;
+        typedef om::ObjectImpl< HttpServerT< tasks::TcpSocketAsyncBase, tasks::TcpServerPolicyQuiet > >     HttpServerQuiet;
+        typedef om::ObjectImpl< HttpServerT< tasks::TcpSslSocketAsyncBase > >                               HttpSslServer;
+        typedef om::ObjectImpl< HttpServerT< tasks::TcpSslSocketAsyncBase, tasks::TcpServerPolicyQuiet > >  HttpSslServerQuiet;
 
     } // httpserver
 

--- a/src/include/baselib/tasks/TcpBaseTasks.h
+++ b/src/include/baselib/tasks/TcpBaseTasks.h
@@ -1382,17 +1382,22 @@ namespace bl
 
         public:
 
-            static bool isLogOnConnect( SAA_in const std::size_t noOfConnections )
+            static bool isLogOnConnect( SAA_in const std::size_t noOfConnections ) NOEXCEPT
             {
                 BL_UNUSED( noOfConnections );
 
                 return ParamIsLogOnConnectAndDisconnect;
             }
 
-            static bool isLogOnDisconnect( SAA_in const std::size_t noOfConnections )
+            static bool isLogOnDisconnect( SAA_in const std::size_t noOfConnections ) NOEXCEPT
             {
                 BL_UNUSED( noOfConnections );
 
+                return ParamIsLogOnConnectAndDisconnect;
+            }
+
+            static bool isLogNoConnections() NOEXCEPT
+            {
                 return ParamIsLogOnConnectAndDisconnect;
             }
         };
@@ -1468,6 +1473,16 @@ namespace bl
             bool isLogOnDisconnect( SAA_in const std::size_t noOfConnections ) NOEXCEPT
             {
                 return isLogInternal( noOfConnections );
+            }
+
+            static bool isLogNoConnections() NOEXCEPT
+            {
+                /*
+                 * It is assumed that servers using smooth policy are under some load most
+                 * of the time and getting to 0 connections is something worth logging.
+                 */
+
+                return true;
             }
         };
 
@@ -1731,7 +1746,7 @@ namespace bl
                 if( ExecutionQueueNotify::AllTasksCompleted == eventId )
                 {
                     BL_LOG(
-                        Logging::debug(),
+                        server_policy_t::isLogNoConnections() ? Logging::debug() : Logging::trace(),
                         BL_MSG()
                             << "No outstanding connections currently open for "
                             << net::formatEndpointId( base_type::m_localEndpoint )

--- a/src/local/apps/bl-messaging-http-gateway/MessagingHttpGatewayApp.h
+++ b/src/local/apps/bl-messaging-http-gateway/MessagingHttpGatewayApp.h
@@ -304,7 +304,7 @@ namespace bl
 
                                     if( cmdLine.m_noTls.hasValue() )
                                     {
-                                        const auto acceptor = bl::httpserver::HttpServer::createInstance(
+                                        const auto acceptor = bl::httpserver::HttpServerQuiet::createInstance(
                                             om::copy( httpBackend ),
                                             controlToken,
                                             "0.0.0.0"                                           /* host */,
@@ -317,7 +317,7 @@ namespace bl
                                     }
                                     else
                                     {
-                                        const auto acceptor = bl::httpserver::HttpSslServer::createInstance(
+                                        const auto acceptor = bl::httpserver::HttpSslServerQuiet::createInstance(
                                             om::copy( httpBackend ),
                                             controlToken,
                                             "0.0.0.0"                                           /* host */,


### PR DESCRIPTION
Logging each connect/disconnect and reaching to 0 connections quickly fills the logs files with not very useful info.