### PR TITLE
Log HTTP server exception messages

### DIFF
--- a/src/include/baselib/httpserver/Parser.h
+++ b/src/include/baselib/httpserver/Parser.h
@@ -230,7 +230,10 @@ namespace bl
                 {
                     return ParserHelpers::serverError(
                         BL_MSG()
-                            << "HTTP content size too large"
+                            << "Content-Length header value "
+                            << m_context.m_expectedBodyLength
+                            << " is larger than the maximum buffer size "
+                            << g_maxContentSize
                         );
                 }
 

--- a/src/include/baselib/httpserver/detail/ParserHelpers.h
+++ b/src/include/baselib/httpserver/detail/ParserHelpers.h
@@ -97,10 +97,13 @@ namespace bl
                     return std::make_pair(
                         HttpParserResult::PARSING_ERROR,
                         std::make_exception_ptr(
-                            BL_EXCEPTION(
-                                HttpServerException(),
-                                message.text()
-                                ))
+                            BL_MAKE_USER_FRIENDLY(
+                                BL_EXCEPTION(
+                                    HttpServerException(),
+                                    message.text()
+                                    )
+                                )
+                            )
                         );
                 }
 


### PR DESCRIPTION
Currently exception message is overridden to a generic one for non-user-friendly exceptions when generating server repose which is being logged. By making the HTTP parser exceptions user friendly the original exception message isn't lost.