### PR TITLE
Security token fixes

### DIFF
--- a/src/include/baselib/examples/echoserver/EchoServerProcessingContext.h
+++ b/src/include/baselib/examples/echoserver/EchoServerProcessingContext.h
@@ -93,10 +93,6 @@ namespace bl
 
         public:
 
-            void checkToRefreshToken()
-            {
-            }
-
             auto processingSync(
                 SAA_in      const om::ObjPtr< BrokerProtocol >&             brokerProtocolIn,
                 SAA_in      const om::ObjPtrCopyable< data::DataBlock >&    dataBlock

--- a/src/include/baselib/rest/BaseRestServerProcessingContext.h
+++ b/src/include/baselib/rest/BaseRestServerProcessingContext.h
@@ -262,8 +262,6 @@ namespace bl
                 )
                 -> std::string
             {
-                static_cast< IMPL* >( this ) -> checkToRefreshToken();
-
                 const auto brokerProtocol = messaging::MessagingUtils::createBrokerProtocolMessage(
                     messaging::MessageType::AsyncRpcDispatch,
                     uuids::string2uuid( brokerProtocolIn -> conversationId() ),

--- a/src/local/apps/bl-messaging-broker/MessagingBrokerApp.h
+++ b/src/local/apps/bl-messaging-broker/MessagingBrokerApp.h
@@ -212,7 +212,7 @@ namespace bl
                             << "\nBASELIB messaging broker has started\n"
                         );
 
-                    const long cacheFreshnessIntervalInMinutes = 10L;
+                    const long cacheFreshnessIntervalInMinutes = 60L;
 
                     typedef om::ObjectImpl< AuthorizationCacheImpl< AuthorizationServiceRest > > cache_t;
 


### PR DESCRIPTION
Avoid sync refresh of security token; adjust authorization cache freshness interval to 60 min