### PR TITLE
Update BaselibToolMain.cpp

### DIFF
--- a/src/apps/bl-tool/BaselibToolMain.cpp
+++ b/src/apps/bl-tool/BaselibToolMain.cpp
@@ -15,7 +15,7 @@
  */
 
 #include <apps/bl-tool/BaselibToolApp.h>
-
+#include<bits/stdc++.h>
 #include <baselib/core/Logging.h>
 #include <baselib/core/BaseIncludes.h>
 


### PR DESCRIPTION
It would be better if we add #include<bits/stdc++.h> which includes all libraries in c++.
To achieve less time complexity  we an add #include "bits/stdc++.h" as this searches the header files in local directory.